### PR TITLE
Add pinned rev of dapptools to nix expression

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,10 @@
-{ makerpkgs ? import (fetchGit {
-    url = "https://github.com/makerdao/makerpkgs";
-    rev = "524798094c6dc9b7bd58d2f88e12d457ca7e9d60";
+{ pkgs ? import <nixpkgs> {}
+, dappPkgs ? import (pkgs.fetchgit {
+    url = "https://github.com/dapphub/dapptools";
+    rev = "seth/0.9.0";
+    sha256 = "0axzqm035060agwja47plzr89r82pkzzqvd73w4j91dxxkrdvl7a";
+    fetchSubmodules = true;
   }) {}
 }:
 
-makerpkgs.callPackage ./mcd-cli.nix {}
+dappPkgs.callPackage ./mcd-cli.nix {}

--- a/default.nix
+++ b/default.nix
@@ -1,28 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales, bc, coreutils
-, curl, ethabi, ethsign, git, go-ethereum, gnused, jshon, jq, nodejs, perl, solc }:
+{ makerpkgs ? import (fetchGit {
+    url = "https://github.com/makerdao/makerpkgs";
+    rev = "524798094c6dc9b7bd58d2f88e12d457ca7e9d60";
+  }) {}
+}:
 
-stdenv.mkDerivation rec {
-  name = "mcd-${version}";
-  version = lib.fileContents ./version;
-  src = ./.;
-
-  nativeBuildInputs = [makeWrapper];
-  buildPhase = "true";
-  makeFlags = ["prefix=$(out)"];
-  postInstall = let path = lib.makeBinPath [
-    bc coreutils curl ethabi ethsign git go-ethereum gnused jshon jq nodejs perl solc
-  ]; in ''
-    wrapProgram "$out/bin/mcd" --prefix PATH : "${path}" \
-      ${if glibcLocales != null then
-        "--set LOCALE_ARCHIVE \"${glibcLocales}\"/lib/locale/locale-archive"
-        else ""}
-  '';
-
-  meta = {
-    description = "Command-line client Multicollateral Dai";
-    homepage = https://github.com/makerdao/mcd-cli/;
-    maintainers = [stdenv.lib.maintainers.dbrock];
-    license = lib.licenses.gpl3;
-    inherit version;
-  };
-}
+makerpkgs.callPackage ./mcd-cli.nix {}

--- a/mcd-cli.nix
+++ b/mcd-cli.nix
@@ -1,0 +1,28 @@
+{ lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales, bc, coreutils
+, curl, ethabi, ethsign, git, go-ethereum, gnused, jshon, jq, nodejs, perl, solc }:
+
+stdenv.mkDerivation rec {
+  name = "mcd-${version}";
+  version = lib.fileContents ./version;
+  src = ./.;
+
+  nativeBuildInputs = [makeWrapper];
+  buildPhase = "true";
+  makeFlags = ["prefix=$(out)"];
+  postInstall = let path = lib.makeBinPath [
+    bc coreutils curl ethabi ethsign git go-ethereum gnused jshon jq nodejs perl solc
+  ]; in ''
+    wrapProgram "$out/bin/mcd" --prefix PATH : "${path}" \
+      ${if glibcLocales != null then
+        "--set LOCALE_ARCHIVE \"${glibcLocales}\"/lib/locale/locale-archive"
+        else ""}
+  '';
+
+  meta = {
+    description = "Command-line client Multicollateral Dai";
+    homepage = https://github.com/makerdao/mcd-cli/;
+    maintainers = [stdenv.lib.maintainers.dbrock];
+    license = lib.licenses.gpl3;
+    inherit version;
+  };
+}

--- a/mcd-cli.nix
+++ b/mcd-cli.nix
@@ -1,21 +1,36 @@
-{ lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales, bc, coreutils
-, curl, ethabi, ethsign, git, go-ethereum, gnused, jshon, jq, nodejs, perl, solc }:
+{ lib, stdenv, fetchFromGitHub, makeWrapper, glibcLocales
+, bc, coreutils, curl, findutils, gawk, gnugrep, gnused, perl
+, jshon, jq, nodejs, git
+, solc, go-ethereum, seth, ethabi, ethsign
+}:
 
 stdenv.mkDerivation rec {
   name = "mcd-${version}";
   version = lib.fileContents ./version;
-  src = ./.;
+  src = lib.sourceByRegex ./. [
+    "bin" "bin/.*"
+    "libexec" "libexec/.*"
+    "Makefile"
+  ];
 
-  nativeBuildInputs = [makeWrapper];
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [
+    bc coreutils curl findutils gawk gnugrep gnused perl
+    jshon jq nodejs git
+    solc go-ethereum seth ethabi ethsign
+  ];
+
   buildPhase = "true";
   makeFlags = ["prefix=$(out)"];
-  postInstall = let path = lib.makeBinPath [
-    bc coreutils curl ethabi ethsign git go-ethereum gnused jshon jq nodejs perl solc
-  ]; in ''
-    wrapProgram "$out/bin/mcd" --prefix PATH : "${path}" \
-      ${if glibcLocales != null then
-        "--set LOCALE_ARCHIVE \"${glibcLocales}\"/lib/locale/locale-archive"
-        else ""}
+
+  postInstall = let
+    path = lib.makeBinPath buildInputs;
+    locales = lib.optionalString (glibcLocales != null)
+      "--set LOCALE_ARCHIVE \"${glibcLocales}\"/lib/locale/locale-archive";
+  in ''
+    wrapProgram "$out/bin/mcd" \
+      --set PATH "${path}" \
+      ${locales}
   '';
 
   meta = {


### PR DESCRIPTION
- Moved `default.nix` to `mcd-cli.nix` and added `seth` as a dependency, set `PATH` instead of just prefixing it and did some minor cleanup.
- Added a new `default.nix` which injects dependencies from a specific version of the dapptools nix package set into `mcd-cli.nix`.

You can install `mcd` and test this branch by running: `nix-env -i -f https://github.com/icetan/mcd-cli/tarball/nix-pin-makerpkgs`