### PR TITLE
Add installer script to mcd-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,19 @@ Commands:
 
 ## Installation
 
-First install [dapp tools](https://dapp.tools):
+First clone mcd-cli(https://github.com/makerdao/mcd-cli/):
 
 ```sh
-$ curl https://dapp.tools/install | sh
+$ git clone https://github.com/makerdao/mcd-cli.git
 ```
 
-Then install the `mcd` package:
+Then run via the installer:
 
 ```sh
-$ dapp pkg install mcd
+$ cd mcd-cli
+$ ./install.sh
 ```
+
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -35,23 +35,26 @@ Commands:
 
 ## Installation
 
-First clone mcd-cli(https://github.com/makerdao/mcd-cli/):
+Install Nix if you haven't already:
 
-```sh
-$ git clone https://github.com/makerdao/mcd-cli.git
+```
+# user must be in sudoers
+curl -L https://nixos.org/nix/install | sh
+
+# Run this or login again to use Nix
+. "$HOME/.nix-profile/etc/profile.d/nix.sh"
 ```
 
 Then run via the installer:
 
 ```sh
-$ cd mcd-cli
-$ ./install.sh
+$ curl https://raw.githubusercontent.com/makerdao/mcd-cli/master/install.sh | sh
 ```
 
 
 ## Configuration
 
-`mcd` is built on [Seth](https://github.com/dapphub/dapptools/tree/master/src/seth) and uses the same network configuration options, which just like Seth, can be defined in the `~/sethrc` initialisation file.
+`mcd` is built on [Seth](https://github.com/dapphub/dapptools/tree/master/src/seth) and uses the same network configuration options, which just like Seth, can be defined in the `~/.sethrc` initialisation file.
 
 Similar to Seth, `mcd` also supports transaction signing with Ledger hardware wallets and can run against both local and remote nodes.
 
@@ -62,7 +65,10 @@ Example `~/.sethrc`:
 ```sh
 #!/usr/bin/env bash
 export ETH_FROM=0x4Ffa8667Fe2db498DCb95A322b448eA688Ce430c
-export MCD_CHAIN=kovan
+export SETH_CHAIN=kovan
+export ETH_PASSWORD="/home/user/makerdao/pass.txt"
+export ETH_KEYSTORE="/home/user/.ethereum/keystore"
+export ETH_RPC_URL="https://kovan.infura.io/v3/c928d...."
 ```
 
 #### Kovan

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+# Based on the Nix install script
+# This script installs Nix, Cachix, and mcd-cli
+
+{ # Prevent execution if this script was only partially downloaded
+
+  set -e
+
+  oops() {
+    echo >&2 "${0##*/}: error:" "$@"
+    exit 1
+  }
+
+  if [ "$(id -u)" -eq 0 ]; then
+    oops "please run this script as a regular user"
+  fi
+
+  if [ -z "$HOME" ]; then
+    oops "\$HOME is not set"
+  fi
+
+  if [ -z "$USER" ]; then
+    oops "\$USER is not set"
+  fi
+
+  have() { command -v "$1" >/dev/null; }
+
+  # We don't handle NixOS yet
+  { have nixos-version; } && {
+    echo >&2 "We love that you are running NixOS! <3"
+    echo >&2 "We're working on having this script work on NixOS, but for the moment"
+    echo >&2 "go to https://github.com/makerdao/mcd-cli/ and follow manual installation instructions."
+    exit 1
+  }
+
+  # Don't auto update Nix v1.
+  { have nix-shell && ! have nix; } && {
+    echo >&2 "You seem to be running a Nix version lower than 2.0"
+    echo >&2 "Please upgrade to Nix v2 before running this script"
+    echo >&2 "You can run \`curl -sS https://nixos.org/nix/install | sh\`"
+    exit 1
+  }
+
+  { have git; } || oops "you need to install Git before running this script"
+  { have curl; } || oops "you need to install curl before running this script"
+
+  { have nix; } || {
+    echo "mcd-cli uses the Nix package manager to install programs behind the scenes."
+    echo "Installing Nix in single-user mode, you may be asked for your sudo password."
+
+    curl -sS https://nixos.org/nix/install | sh
+
+    # shellcheck source=/dev/null
+    . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+    echo "Nix installation succeded!"
+  }
+
+  if [ ! -d "$HOME/.config/nix" ]; then
+    mkdir -p "$HOME/.config/nix"
+  fi
+
+  echo "Installing mcd-cli... (this will take a while)"
+  nix-env -i -f https://github.com/makerdao/mcd-cli/tarball/master
+
+  # Finished!
+  cat <<EOF
+
+Installation finished!
+
+You now have access to mcd-cli.
+
+Please logout and log back in to start using mcd-cli, or run
+
+    . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+
+in this terminal.
+EOF
+
+} # End of wrapping


### PR DESCRIPTION
Adds an installer script to `mcd-cli`

The readme is updated for `master` branch. To test the installer on this branch, invoke:

```
curl https://raw.githubusercontent.com/makerdao/mcd-cli/installer/install.sh | sh
```