### PR TITLE
Get adapter address from registry

### DIFF
--- a/libexec/mcd/mcd
+++ b/libexec/mcd/mcd
@@ -67,7 +67,7 @@ testnet-init() {
   conf="$dir/conf.json";
 
   if [[ ! -d "$dir" ]]; then
-    json=$(mcd testnet chain ${1} | jq '.')
+    json=$(mcd testnet chain "${1}" | jq '.')
     if [[ "$json" == "null" ]]; then
       echo "Error: chain config not found for $1"
       exit 1

--- a/libexec/mcd/mcd---require-ilk
+++ b/libexec/mcd/mcd---require-ilk
@@ -41,7 +41,7 @@ exit 1
 }
 
 valid-ilks() {
-  echo $(mcd ilks | cut -d ' ' -f 1)
+  echo $(mcd ilks | cut -d ' ' -f 1)  # no shellcheck
 }
 
 [ -n "$MCD_ILK" ] || missing-ilk

--- a/libexec/mcd/mcd-gem
+++ b/libexec/mcd/mcd-gem
@@ -29,8 +29,9 @@ fi
 
 case $1 in
   adapter)
-    ilk=$(tr '-' '_' <<<"$MCD_ILK")
-    eval echo "\$MCD_JOIN_$ilk"
+    ilk="$(mcd --get-ilk)"
+    join="$(seth call "${ILK_REGISTRY?}" 'join(bytes32)(address)' "${ilk}")"
+    echo "$join"
   ;;
   gem|address)
     gem=$(seth call "$(mcd gem adapter)" 'gem()')

--- a/libexec/mcd/mcd-gem
+++ b/libexec/mcd/mcd-gem
@@ -30,8 +30,7 @@ fi
 case $1 in
   adapter)
     ilk="$(mcd --get-ilk)"
-    join="$(seth call "${ILK_REGISTRY?}" 'join(bytes32)(address)' "${ilk}")"
-    echo "$join"
+    seth call "${ILK_REGISTRY?}" 'join(bytes32)(address)' "${ilk}"
   ;;
   gem|address)
     gem=$(seth call "$(mcd gem adapter)" 'gem()')
@@ -50,7 +49,7 @@ case $1 in
     mcd-gem-balance "$2";
   ;;
   supply)
-    ilk=$(mcd --get-ilk)
+    ilk="$(mcd --get-ilk)"
     case $2 in
       mcd) { mcd gem-supply; };;
       ext) { mcd gem-supply-ext; };;

--- a/libexec/mcd/mcd-ilk
+++ b/libexec/mcd/mcd-ilk
@@ -6,16 +6,26 @@
 ### With `<param>` get a specified Ilk parameter
 ###
 ### Example: mcd --ilk=ETH-A ilk
-###          mcd --ilk=ETH-A ilk spot
 ###          mcd --ilk=ETH-A ilk Art
+###          mcd --ilk=ETH-A ilk rate
+###          mcd --ilk=ETH-A ilk spot
+###          mcd --ilk=ETH-A ilk line
+###          mcd --ilk=ETH-A ilk dust
+###          mcd --ilk=ETH-A ilk flip
+###          mcd --ilk=ETH-A ilk chop
+###          mcd --ilk=ETH-A ilk lump
+###          mcd --ilk=ETH-A ilk duty
+###          mcd --ilk=ETH-A ilk rho
+###          mcd --ilk=ETH-A ilk pip
+###          mcd --ilk=ETH-A ilk mat
 set -e
 
-id=$(mcd --get-ilk)
+id="$(mcd --get-ilk)"
 
-vat()  { mcd --vat-ilk $id;  }
-cat()  { mcd --cat-ilk $id;  }
-jug()  { mcd --jug-ilk $id;  }
-spot() { mcd --spot-ilk $id; }
+vat()  { mcd --vat-ilk "$id";  }
+cat()  { mcd --cat-ilk "$id";  }
+jug()  { mcd --jug-ilk "$id";  }
+spot() { mcd --spot-ilk "$id"; }
 
 p() { printf "%-4s %-52s %-10s\n" "$1" "$2" "$3"; }
 


### PR DESCRIPTION
* Gets the join adapter address from the registry instead of the config file (new ilks won't be in json)
* Updates some documentation and refactors some things.