### PR TITLE
Change tempfile name and use chain name to prevent collision when switching networks

### DIFF
--- a/libexec/mcd/mcd-ilks
+++ b/libexec/mcd/mcd-ilks
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-FILENAME="ilk-types.txt"
+FILENAME="org.makerdao.ilks.${SETH_CHAIN}"
 FILEPATH="/tmp/$FILENAME"
 
 function writeData {
@@ -39,7 +39,7 @@ function writeData {
 # Cache the ilk data and only re-acquire every 10 minutes if not in active use
 if [[ -f "$FILEPATH" && $(($(date +%s)-$(date -r $FILEPATH +%s))) -lt "600" ]]; then
     # Update modification time
-    touch -m $FILEPATH
+    touch -m "$FILEPATH"
 else
     # File is stale, re-acquire and rewrite
     writeData


### PR DESCRIPTION
This fixes a bug in the ilk list caching when switching networks by changing the tempfile name for each network.
Also updates the tempfile name to reduce chances of collision.