### PR TITLE
Fix rounding bug

### DIFF
--- a/libexec/mcd/mcd-cdp
+++ b/libexec/mcd/mcd-cdp
@@ -6,12 +6,12 @@
 ###           count [<owner>]                 Cdp count
 ###           open                            Open a new Cdp
 ###           <id> urn                        Cdp state
-###           <id> lock <wad>                 Join & lock standard gem collateral
-###           <id> safe-lock <wad>            Join & safely lock standard gem collateral (checks it is your CDP)
-###           <id> free <wad>                 Free & exit standard gem collateral
-###           <id> draw <wad>                 Draw & exit dai
-###           <id> wipe <wad>                 Join & wipe dai
-###           <id> safe-wipe <wad>            Join & wipe dai (checks it is your CDP)
+###           <id> lock <amt>                 Join & lock standard gem collateral (amt in currency units)
+###           <id> safe-lock <amt>            Join & safely lock standard gem collateral (checks it is your CDP)
+###           <id> free <amt>                 Free & exit standard gem collateral
+###           <id> draw <amt>                 Draw & exit dai
+###           <id> wipe <amt>                 Join & wipe dai
+###           <id> safe-wipe <amt>            Join & wipe dai (checks it is your CDP)
 ###           <id> wipe-all                   Join & wipe dai to leave debt=0
 ###           <id> safe-wipe-all              Join & wipe dai to leave debt=0 (checks it is your CDP)
 ###           <id> give <address>             Give a Cdp to another owner

--- a/libexec/mcd/mcd-cdp-cmd
+++ b/libexec/mcd/mcd-cdp-cmd
@@ -16,7 +16,7 @@ require-wad() {
 require-amount() {
   [ -n "$1" ] || mcd --fail "mcd-cdp: Please specify an amount to $act"
   decimals=$(mcd gem decimals)
-  amount="$(echo "$1 * 10^$decimals" | bc)"
+  amount="$(printf "%.0f" "$(echo "$1 * 10^$decimals" | bc)")"
 }
 
 require-dst() {

--- a/libexec/mcd/mcd-gem-exit
+++ b/libexec/mcd/mcd-gem-exit
@@ -8,7 +8,7 @@ gem="$(mcd gem address)"
 exit="$(mcd gem adapter)"
 decimals="$(mcd gem decimals)"
 
-amount="$(echo "$1 * 10^$decimals" | bc)"
+amount="$(printf "%.0f" "$(echo "$1 * 10^$decimals" | bc)")"
 
 urn="$(mcd --get-urn "$gem")"
 

--- a/libexec/mcd/mcd-gem-join
+++ b/libexec/mcd/mcd-gem-join
@@ -7,7 +7,7 @@ mcd --require-ilk
 gem="$(mcd gem address)"
 join="$(mcd gem adapter)"
 decimals="$(mcd gem decimals)"
-amount="$(echo "$1 * 10^$decimals" | bc)"
+amount="$(printf "%.0f" "$(echo "$1 * 10^$decimals" | bc)")"
 
 mcd --gem-approve "$join" "$amount"
 


### PR DESCRIPTION
This fixes a bug when attempting a `cdp-cmd` on a partial collateral amount. The amount is multiplied by the token decimals and `bc` adds trailing decimals when the user enters a fractional amount. Solution here is to round off the additional decimals to work in integer amounts.

Also, the existing documentation here indicates that a `wad` value should be used, when a whole collateral unit is actually used, fixed the documentation here but will need to see if there are any other places in the code where the documentation is misleading.