### PR TITLE
Fix collateralization ratio calculation

### DIFF
--- a/libexec/mcd/mcd-urn
+++ b/libexec/mcd/mcd-urn
@@ -19,13 +19,15 @@ p() { printf "%-4s %-48s %-10s\n" "$1" "$2" "$3"; }
 calc() {
   exec 3< <(mcd ilk spot)
   exec 4< <(mcd ilk rate)
+  exec 5< <(mcd ilk mat)
   spot=$(cat <&3);
   rate=$(cat <&4);
+  mat=$(cat <&5);
   rat=0; rap=0; tab=0
   if [ "${art:0:1}" -gt 0 ]; then
     tab=$(printf '%.27f\n' "$(bc <<< "$art*$rate")")
     rap=$(printf '%.27f\n' "$(bc <<< "$tab - $art")")
-    rat=$(bc <<< "scale=2; (($ink*$spot)/$tab)")
+    rat=$(bc <<< "scale=2; (($ink*$spot*$mat)/$tab)")
   fi
 }
 

--- a/libexec/mcd/mcd-urn
+++ b/libexec/mcd/mcd-urn
@@ -27,7 +27,7 @@ calc() {
   if [ "${art:0:1}" -gt 0 ]; then
     tab=$(printf '%.27f\n' "$(bc <<< "$art*$rate")")
     rap=$(printf '%.27f\n' "$(bc <<< "$tab - $art")")
-    rat=$(bc <<< "scale=2; (($ink*$spot*$mat)/$tab)")
+    rat=$(bc <<< "scale=6; (($ink*$spot*$mat)/$tab)")
   fi
 }
 


### PR DESCRIPTION
The existing calculation was using `spot` in place of the OSM price.  Since spot is divided by the liquidation ratio (`mat`), we need to multiply by it to turn it into a market price.