### PR TITLE
Gem output fixups

### DIFF
--- a/libexec/mcd/mcd-gem
+++ b/libexec/mcd/mcd-gem
@@ -37,13 +37,13 @@ case $1 in
     seth --abi-decode 'f()(address)' "$gem"
   ;;
   name)
-    mcd ilks | sed -n "/$MCD_ILK/p" | awk '{$1=$2=$3=""; print $0}' | sed 's/^ *//g'
+    mcd ilks | sed -n "/^$MCD_ILK/p" | awk '{$1=$2=$3=""; print $0}' | sed 's/^ *//g'
   ;;
   symbol)
-    mcd ilks | sed -n "/$MCD_ILK/p" | awk '{print $2}'
+    mcd ilks | sed -n "/^$MCD_ILK/p" | awk '{print $2}'
   ;;
   decimals)
-    mcd ilks | sed -n "/$MCD_ILK/p" | awk '{print $3}'
+    mcd ilks | sed -n "/^$MCD_ILK/p" | awk '{print $3}'
   ;;
   balance)
     mcd-gem-balance "$2";

--- a/libexec/mcd/mcd-gem-balance
+++ b/libexec/mcd/mcd-gem-balance
@@ -19,14 +19,16 @@ case $1 in
   "")   {
     exec 3< <(mcd gem balance vat)
     exec 4< <(mcd gem balance ink)
-    exec 5< <(mcd gem balance ext)
     echo "vat $(cat <&3) Unlocked collateral ($gem)"
     echo "ink $(cat <&4) Locked collateral ($gem)"
-    echo "ext $(cat <&5) External account balance ($gem)"
-    if [[ "$gem" == "WETH" ]]; then
-      eth=$(mcd --to-wad "$(seth --to-hex "$(seth balance "$ETH_FROM")")")
-      echo "eth $eth External account balance (ETH)"
-      echo
+    if [[ ! -z "$ETH_FROM" ]]; then
+      exec 5< <(mcd gem balance ext)
+      echo "ext $(cat <&5) External account balance ($gem)"
+      if [[ "$gem" == "WETH" ]]; then
+        eth=$(mcd --to-wad "$(seth --to-hex "$(seth balance "$ETH_FROM")")")
+        echo "eth $eth External account balance (ETH)"
+        echo
+      fi
     fi
   };;
   *)   { mcd gem balance; };;


### PR DESCRIPTION
Hi, my platform is 

```
ProductName:	Mac OS X
ProductVersion:	10.15.6
BuildVersion:	19G2021
```

When playing around with `mcd` to learn about the Maker system  I noticed the following odd looking output:

```
./bin/mcd --chain mainnet --ilk=ETH-A --urn=0xF949272B728F32Ea6CB5543Fe0DCcE8aBF6fEe4B gem balance

vat 0.000000000000000000 Unlocked collateral (WETH
UNI-V2
UNI-V2
UNI-V2
UNI-V2
UNI-V2
UNI-V2)
ink 0.000000000000000000 Locked collateral (WETH
UNI-V2
UNI-V2
UNI-V2
UNI-V2
UNI-V2
UNI-V2)
hevm: could not parse abi argument:  : address
CallStack (from HasCallStack):
  error, called at src/EVM/ABI.hs:485:8 in hevm-0.48.0-JFbaB4z3V2D4yuHF1ql3y4:EVM.ABI
ext  External account balance (WETH
UNI-V2
UNI-V2
UNI-V2
UNI-V2
UNI-V2
UNI-V2)
```

I added a start-of-line anchor to sed to eliminate the multiline matching of GEMs (first commit), but then that left the issue of  "bad argument `address`" when `ETH_FROM` is not set. I added a guard as a second commit to eliminate the `Callstack` dump, so now if `ETH_FROM` is unset you get

```
./bin/mcd --chain mainnet --ilk=ETH-A --urn=0xF949272B728F32Ea6CB5543Fe0DCcE8aBF6fEe4B gem balance
vat 0.000000000000000000 Unlocked collateral (WETH)
ink 0.000000000000000000 Locked collateral (WETH)
```

and when it's set you'll get the following output:

```
ETH_FROM=0x0000000000000000000000000000000000000000 ./bin/mcd --chain mainnet --ilk=ETH-A --urn=0xF949272B728F32Ea6CB5543Fe0DCcE8aBF6fEe4B gem balance
vat 0.000000000000000000 Unlocked collateral (WETH)
ink 0.000000000000000000 Locked collateral (WETH)
ext 1.131487362908677203 External account balance (WETH)
eth 11269.408812248300628127 External account balance (ETH)
```

Happy to revise if there are any issues or I've overlooked something. 